### PR TITLE
[rig] Use `tempfile` module for temp directory creation

### DIFF
--- a/rigging/rigs/__init__.py
+++ b/rigging/rigs/__init__.py
@@ -18,6 +18,7 @@ import string
 import socket
 import sys
 import tarfile
+import tempfile
 import time
 
 from argparse import Action
@@ -110,7 +111,7 @@ class BaseRig():
             self.log_debug("Initializing %s rig %s" %
                            (self.resource_name, self.id))
             self._sock, self._sock_address = self._create_rig_socket()
-            self._tmp_dir = self._create_temp_dir()
+            self._create_temp_dir()
             self.files = []
 
     def set_rig_id(self):
@@ -196,11 +197,11 @@ class BaseRig():
         Create a temp directory for rig to use for saving created files too
         """
         try:
-            _dir = "%s.%s/" % (RIG_TMP_DIR_PREFIX, self.id)
-            os.makedirs(_dir)
-            return _dir
-        except OSError:
-            raise CannotConfigureRigError('failed to create temp directory')
+            self._tmp_dir = tempfile.mkdtemp(prefix='rig.', dir='/var/tmp')
+        except Exception as err:
+            raise CannotConfigureRigError(
+                "failed to create temp directory: %s" % err
+            )
 
     def _load_args(self):
         """


### PR DESCRIPTION
Previously, a change was made to temp directory creation in an effort to
make it more secure. While that was largely handled, it left us with an
unhandled error in an edge case configuration. Rather than putting a
band-aid over that again, re-write the temp directory creation process
to leverage the `tempfile` module, so that we can safely and completely
ignore the id/name of a rig, and leave the use of that for the
communication socket.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>