### PR TITLE
[rig] Cleanup tempdir even if no data generated

### DIFF
--- a/rigging/rigs/__init__.py
+++ b/rigging/rigs/__init__.py
@@ -776,7 +776,7 @@ class BaseRig():
             pass
 
         try:
-            if self.archive_name or self._status == 'destroying':
+            if not self.get_option('no_archive'):
                 shutil.rmtree(self._tmp_dir)
         except Exception as err:
             self.log_error("Could not remove temp dir: %s" % err)


### PR DESCRIPTION
Previously, we would erroneously not remove a rig's temp dir if it
generated no data. Specifically, this could mean left over temp
directories when using the `--noop` action to test rig configurations.

Fix this by not relying on an archive name to remove the temp dir, and
instead only leave the directory in place if we are specifically not
building an archive.

Signed-off-by: Jake Hunsaker <jhunsake@redhat.com>