### PR TITLE
[rigcmd] Add a default ui logger for console output

### DIFF
--- a/rigging/commands/__init__.py
+++ b/rigging/commands/__init__.py
@@ -44,6 +44,12 @@ class RigCmd():
         :type options:  dict
         """
         self.options = options
+        # always create a ui logger. Anything sent to rig.log or similar will
+        # need to have that RigCmd call _setup_logging()
+        self.ui_logger = logging.getLogger('rig_ui')
+        self.ui_logger.setLevel(logging.INFO)
+        console = logging.StreamHandler()
+        self.ui_logger.addHandler(console)
 
     @classmethod
     def add_parser_options(cls, parser):

--- a/rigging/commands/create.py
+++ b/rigging/commands/create.py
@@ -98,7 +98,7 @@ class CreateCmd(RigCmd):
             raise
         try:
             base.detach()
-            print(f"Created rig {self.name} successfully")
+            self.ui_logger.info(f"Created rig {self.name} successfully")
         except Exception as err:
             self.logger.error(f"Could not detach from console: {err}")
             raise

--- a/rigging/commands/destroy.py
+++ b/rigging/commands/destroy.py
@@ -8,7 +8,6 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
-import sys
 
 from rigging.commands import RigCmd
 from rigging.connection import RigDBusConnection
@@ -42,10 +41,10 @@ class DestroyCmd(RigCmd):
         for target in self.options['rig_id']:
             try:
                 result = self._run_destroy(target)
-                sys.stdout.write(f"Rig '{target}': {result}\n")
+                self.ui_logger.info(f"Rig '{target}': {result}")
             except Exception as err:
                 # don't stop iteration due to one bad attempt
-                sys.stdout.write(f"{err}\n")
+                self.ui_logger.error(f"{err}")
 
     def _run_destroy(self, target):
         try:

--- a/rigging/commands/list.py
+++ b/rigging/commands/list.py
@@ -9,7 +9,6 @@
 # See the LICENSE file in the source distribution for further information
 
 import dbus
-import sys
 
 from rigging.commands import RigCmd
 from rigging.connection import RigDBusConnection
@@ -44,17 +43,17 @@ class ListCmd(RigCmd):
             19
         )
 
-        sys.stdout.write(
+        self.ui_logger.info(
             f"{'NAME':<{nameln+1}}{'STARTED':<21}{'MONITORS':<{monln+1}}"
-            f"{'ACTIONS':<{actln+1}}{'STATUS':<10}\n"
+            f"{'ACTIONS':<{actln+1}}{'STATUS':<10}"
         )
 
         for rig in rigs:
             _rig = rigs[rig]
-            sys.stdout.write(
+            self.ui_logger.info(
                 f"{_rig['name'][:nameln]:<{nameln+1}}"
                 f"{_rig['start_time'].split('.')[0].replace('T', ' '):<21}"
                 f"{_rig['monitors'][:monln]:<{monln+1}}"
                 f"{_rig['actions'][:actln]:<{actln+1}}"
-                f"{_rig['status']:<10}\n"
+                f"{_rig['status']:<10}"
             )

--- a/rigging/connection.py
+++ b/rigging/connection.py
@@ -215,7 +215,7 @@ class RigDBusListener(dbus.service.Object):
                 err(RigDBusMessage("Command `destroy` not implemented.",
                     False).serialize())
 
-            self.loggr.info("Destroying rig")
+            self.logger.info("Destroying rig")
 
             # this callback is expected to terminate the process, so we need
             # to send feedback to the client before the function is called.


### PR DESCRIPTION
Adds a `ui_logger` attribute to any `RigCmd` so that there is by default a reliable way to print to console, and not just log to a file.