### PR TITLE
[info] Reimplement `rig info` command

### DIFF
--- a/rigging/actions/__init__.py
+++ b/rigging/actions/__init__.py
@@ -197,3 +197,22 @@ class BaseAction():
                 f"{', '.join(f.split('/')[-1] for f in self.action_files)}"
             )
         return self.action_files
+
+    def get_info(self):
+        """
+        Get information on the action and it's configuration in a way that is
+        easily returned by the `rig info` command. This should be a dict that
+        can be converted to JSON (so type restrictions apply).
+
+        Calls the action's `produces` property.
+
+        :return: dict containing configuration information
+        """
+        return {
+            'type': self.action_name,
+            'produces': self.produces
+        }
+
+    @property
+    def produces(self):
+        return 'undefined'

--- a/rigging/actions/gcore.py
+++ b/rigging/actions/gcore.py
@@ -165,3 +165,10 @@ class GcoreAction(BaseAction):
 
         if _frozen:
             self.thaw_pid(pid)
+
+    @property
+    def produces(self):
+        return [
+          f"core-{count}.{proc}" for count in range(self.config['repeat'] + 1)
+          for proc in self.procs
+        ]

--- a/rigging/actions/kdump.py
+++ b/rigging/actions/kdump.py
@@ -72,3 +72,7 @@ class KdumpAction(BaseAction):
         )
         with open('/proc/sysrq-trigger', 'w') as sysrq:
             sysrq.write('c')
+
+    @property
+    def produces(self):
+        return "A vmcore at your configured crash location following restart"

--- a/rigging/actions/noop.py
+++ b/rigging/actions/noop.py
@@ -29,3 +29,7 @@ class Noop(BaseAction):
         if not enabled:
             raise Exception("noop action requested but explicitly disabled")
         return True
+
+    @property
+    def produces(self):
+        return None

--- a/rigging/actions/sos.py
+++ b/rigging/actions/sos.py
@@ -244,3 +244,7 @@ class SosAction(BaseAction):
 
         _config['command'] = cmd
         return _config
+
+    @property
+    def produces(self):
+        return "an sos report tarball for this system"

--- a/rigging/actions/tcpdump.py
+++ b/rigging/actions/tcpdump.py
@@ -161,3 +161,8 @@ class TcpdumpAction(BaseAction):
             self.devnull.close()
         except Exception as err:
             self.logger.error(f"Error during tcpdump cleanup: {err}")
+
+    @property
+    def produces(self):
+        basename = self.outfn.split('/')[-1]
+        return [f"{basename}{x}" for x in range(self.capture_count)]

--- a/rigging/actions/watch.py
+++ b/rigging/actions/watch.py
@@ -316,3 +316,10 @@ class WatchAction(BaseAction):
             )
             self.logger.info(f"Waiting for collectors {stopped} to stop")
             time.sleep(self.config['interval'])
+
+    @property
+    def produces(self):
+        return {
+            'file_content': [f['dest'] for f in self.files],
+            'command_output': [c['filename'] for c in self.commands]
+        }

--- a/rigging/commands/info.py
+++ b/rigging/commands/info.py
@@ -8,7 +8,11 @@
 #
 # See the LICENSE file in the source distribution for further information.
 
+import json
+
 from rigging.commands import RigCmd
+from rigging.connection import RigDBusConnection
+from rigging.exceptions import DBusServiceDoesntExistError
 
 
 class InfoCmd(RigCmd):
@@ -20,7 +24,12 @@ class InfoCmd(RigCmd):
 
     @classmethod
     def add_parser_options(cls, parser):
-        parser.add_argument('-i', '--id', help='The ID of the rig')
+        parser.add_argument('rig_id', help='The ID of the rig')
 
     def execute(self):
-        print('placeholder')
+        try:
+            conn = RigDBusConnection(self.options['rig_id'])
+            _i = conn.info().result
+            self.ui_logger.info(json.dumps(_i, indent=4))
+        except DBusServiceDoesntExistError:
+            raise Exception(f"No such rig: {self.options['rig_id']}")

--- a/rigging/connection.py
+++ b/rigging/connection.py
@@ -114,6 +114,9 @@ class RigDBusConnection:
     def describe(self):
         return self._communicate(RigDBusCommand("describe"))
 
+    def info(self):
+        return self._communicate(RigDBusCommand('info'))
+
 
 class RigDBusListener(dbus.service.Object):
     """
@@ -247,5 +250,20 @@ class RigDBusListener(dbus.service.Object):
             ok(RigDBusMessage(_info, True).serialize())
         except Exception as error:
             msg = f"Could not get description: {error}"
+            self.logger.error(msg)
+            err(Exception(msg))
+
+    @dbus.service.method('com.redhat.RigInterface', in_signature='',
+                         out_signature='a{ss}', async_callbacks=('ok', 'err'))
+    def info(self, ok, err):
+        """
+        Get detailed information about the rig and it's configuration
+        :return:
+        """
+        try:
+            _func = self._get_mapped_method('info', err)
+            ok(RigDBusMessage(_func(), True).serialize())
+        except Exception as error:
+            msg = f"Could not determine info: {error}"
             self.logger.error(msg)
             err(Exception(msg))

--- a/rigging/monitors/__init__.py
+++ b/rigging/monitors/__init__.py
@@ -116,3 +116,25 @@ class BaseMonitor():
         to do so consistently and according to the set value of `interval`.
         """
         time.sleep(self.config['interval'])
+
+    def get_info(self):
+        """
+        Used to return information about this monitor for the `rig info`
+        command. This will in turn call the monitor's `monitoring` property.
+
+        :return: dict containing the monitor type and what it is configured to
+                 monitor
+        """
+        return {
+            'type': self.monitor_name,
+            'monitoring': self.monitoring
+        }
+
+    @property
+    def monitoring(self):
+        """
+        This SHOULD BE overridden by specific monitors.
+        This method should describe in human-friendly terms what the monitor
+        is watching for in order to trigger the rig.
+        """
+        return 'undefined'

--- a/rigging/monitors/cpu.py
+++ b/rigging/monitors/cpu.py
@@ -70,6 +70,9 @@ class CpuMonitor(BaseMonitor):
                 (float(percent), )
             )
 
+        # save this to the instance so that self.monitoring can report on it
+        self.metrics = _metrics.copy()
+
         _metrics.pop('percent')
 
         if any(m is not None for m in _metrics.values()):
@@ -117,3 +120,11 @@ class CpuMonitor(BaseMonitor):
                         f" of {_monitor[_mon]}%"
                     )
                     return True
+
+    @property
+    def monitoring(self):
+        _info = {}
+        for metric in self.metrics:
+            if self.metrics[metric] is not None:
+                _info[metric] = f">= {self.metrics[metric]}%"
+        return _info

--- a/rigging/monitors/filesystem.py
+++ b/rigging/monitors/filesystem.py
@@ -41,6 +41,12 @@ class Filesystem(BaseMonitor):
         if not self.path.exists():
             raise Exception(f"Provided path '{path}' does not exist")
 
+        self.stats = {
+            'size': size,
+            'used_perc': used_perc,
+            'used_size': used_size
+        }
+
         if size:
             self.add_monitor_thread(self.watch_path_size, (size,))
 
@@ -111,3 +117,11 @@ class Filesystem(BaseMonitor):
                 )
                 return True
             self.wait_loop()
+
+    @property
+    def monitoring(self):
+        info = {'path': self.path.as_posix()}
+        for k, v in self.stats.items():
+            if v is not None:
+                info[k] = f">= {v}"
+        return info

--- a/rigging/monitors/logs.py
+++ b/rigging/monitors/logs.py
@@ -202,3 +202,11 @@ class Logs(BaseMonitor):
                                  f"matching specified count configuration.")
                 return True
         return False
+
+    @property
+    def monitoring(self):
+        return {
+            'message': self.message.pattern,
+            'files': self.files,
+            'journals': self.journals
+        }

--- a/rigging/monitors/memory.py
+++ b/rigging/monitors/memory.py
@@ -37,6 +37,9 @@ class MemoryMonitor(BaseMonitor):
             'slab': slab
         }
 
+        # save original state for info reports
+        self.stats = _mem_metrics.copy()
+
         if not any(m is not None for m in _mem_metrics.values()):
             raise Exception(
                 f"Must specify at least one of "
@@ -107,3 +110,11 @@ class MemoryMonitor(BaseMonitor):
                     )
                     return True
             self.wait_loop()
+
+    @property
+    def monitoring(self):
+        _info = {}
+        for k, v in self.stats.items():
+            if v is not None:
+                _info[k] = f">= {v}{'%' if k == 'percent' else ''}"
+        return _info

--- a/rigging/monitors/packet.py
+++ b/rigging/monitors/packet.py
@@ -328,3 +328,11 @@ class Packet(BaseMonitor):
                     f"Packet matching {match_str} found: {pkt_str}"
                 )
                 return True
+
+    @property
+    def monitoring(self):
+        _info = {
+            'interface': self._match_ifname
+        }
+        _info.update({k: str(v) for k, v in self._must_match.items()})
+        return _info

--- a/rigging/monitors/system.py
+++ b/rigging/monitors/system.py
@@ -33,6 +33,8 @@ class SystemMonitor(BaseMonitor):
                 'Must specify at least one of \'temperature\', or \'loadavg\''
             )
 
+        self.stats = {}
+
         if temperature is not None:
             self._configure_temp_monitor(temperature)
 
@@ -53,6 +55,7 @@ class SystemMonitor(BaseMonitor):
                 f"{temperature.__class__}."
             )
         self.add_monitor_thread(self.watch_temperature, (temp,))
+        self.stats['temperature'] = f"{temp}C"
 
     def _configure_loadavg_monitor(self, loadavg, loadavg_interval):
         try:
@@ -65,6 +68,7 @@ class SystemMonitor(BaseMonitor):
                             f"Not {loadavg_interval}.")
         self.add_monitor_thread(self.watch_loadavg,
                                 (loadavg, loadavg_interval))
+        self.stats['loadavg'] = f">= {loadavg} (interval: {loadavg_interval})"
 
     def watch_temperature(self, temp):
         """
@@ -105,3 +109,7 @@ class SystemMonitor(BaseMonitor):
                 )
                 return True
             self.wait_loop()
+
+    @property
+    def monitoring(self):
+        return self.stats


### PR DESCRIPTION
This patchset adds the `rig info` command, which can be used to get more detailed information about a given rig than is available via `rig list`.

This information is meant to reflect the configuration of the rig and specify what the expected outputs of a rig's actions are.