### PR TITLE
[timer] Add new timer monitor

### DIFF
--- a/rigging/__init__.py
+++ b/rigging/__init__.py
@@ -18,7 +18,7 @@ from concurrent.futures import ThreadPoolExecutor, wait, FIRST_COMPLETED
 from concurrent.futures import thread
 from datetime import datetime
 from rigging.connection import RigDBusListener
-from rigging.exceptions import CannotConfigureRigError
+from rigging.exceptions import CannotConfigureRigError, DestroyRig
 from rigging.utilities import load_rig_monitors, load_rig_actions
 
 
@@ -332,6 +332,8 @@ class BaseRig():
             result = list(results[0])[0].result()
             self.logger.info('Monitor thread completed. Triggering rig.')
             return result
+        except DestroyRig:
+            self._destroy_self()
         except Exception as err:
             self.logger.error(f"Exception caught for rig {self.name}: {err}")
             self._exit(1)

--- a/rigging/monitors/timer.py
+++ b/rigging/monitors/timer.py
@@ -1,0 +1,95 @@
+# Copyright (C) 2023 Red Hat, Inc., Jake Hunsaker <jhunsake@redhat.com>
+
+# This file is part of the rig project: https://github.com/TurboTurtle/rig
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information
+
+import re
+import time
+
+from datetime import timedelta, datetime
+from rigging.monitors import BaseMonitor
+from rigging.exceptions import DestroyRig
+
+UNITS = {
+    's': 'seconds',
+    'm': 'minutes',
+    'h': 'hours',
+    'd': 'days',
+    'w': 'weeks'
+}
+
+
+def convert_to_seconds(timestr):
+    _times = {}
+    for m in re.finditer(r'(?P<val>\d+(\.\d+)?)(?P<unit>[smhdw]?)',
+                         timestr, re.I):
+        unit = UNITS.get(m.group('unit').lower(), 'seconds')
+        _times[unit] = float(m.group('val'))
+    return int(timedelta(**_times).total_seconds())
+
+
+class TimerMonitor(BaseMonitor):
+    """
+    This monitor is used to set an upper bound for how long a given rig will
+    run for before terminating. The default behavior is to trigger the rig when
+    the timer expires, but this can be controlled via the `trigger_on_expiry`
+    parameter within the rigfile - setting the value to False will cause the
+    rig to simply terminate without triggering.
+
+    The `timeout` parameter accepts either a raw value in seconds, or a string
+    representation using standard signifiers such as `s` for seconds, `m` for
+    minutes, `h` for hours, `d` for days, and `w` for weeks. You can use
+    multiple of these signifiers in a single string passed to this parameter,
+    e.g. `1d 2h 30m` for 1 day, 2 hours, and 30 minutes from the time the rig
+    starts.
+    """
+
+    monitor_name = 'timer'
+
+    def configure(self, timeout, trigger_on_expiry=True):
+        """
+        :param timeout: How long to allow the rig to run for
+        :type timeout: `int` or `str` representation of time value
+
+        :param trigger_on_expiry: Should the rig trigger actions after timeout?
+        :type trigger_on_expiry: `bool`
+        """
+        self.trigger_on_expiry = trigger_on_expiry
+        try:
+            seconds = convert_to_seconds(str(timeout))
+        except Exception as err:
+            raise Exception(f"Unable to parse timeout string: {err}")
+        self.add_monitor_thread(self.monitor_timeout, (seconds, ))
+
+    def monitor_timeout(self, seconds):
+        """
+        This method just sleeps until the timeout is up. If trigger_on_expiry
+        was configured (default: True), the rig will be triggered and actions
+        will be fired off as expected. If set to False, the rig will terminate
+        without triggering actions.
+
+        :param seconds: The timeout given to the rig, converted to seconds
+        """
+        when = datetime.now() + timedelta(seconds=seconds)
+        self.logger.info(
+            f"Beginning timer monitor. Timeout will expire at "
+            f"{when.strftime('%Y/%m/%d %I:%M %p')}"
+        )
+
+        while True:
+            diff = (when - datetime.now()).total_seconds()
+            if diff < 1:
+                break
+            time.sleep(diff / 2)
+
+        self.logger.info("Timer monitor timeout expired.")
+        if self.trigger_on_expiry:
+            return True
+        raise DestroyRig(
+            'timeout expired in timer monitor with trigger_on_expiry = False'
+        )


### PR DESCRIPTION
This commit adds a new `timer` monitor, which simply serves to provide a maximum run time for the rig. This monitor accepts two parameters in a rigfile:

  1. `timeout`, which specifies how much time to wait until the monitor triggers. This parameter can take either a raw value in seconds, or a more human-friendly string such as `1h 30m` for example.

  2. `trigger_on_expiry`, which controls if the timeout expiring triggers the rig, or simply causes the rig to be removed without triggering actions. Default is true (trigger actions on timeout).

Resolves: #45