### PR TITLE
[trigger] Reimplement `trigger` command for CLI

### DIFF
--- a/rigging/commands/trigger.py
+++ b/rigging/commands/trigger.py
@@ -1,0 +1,41 @@
+# Copyright (C) 2023 Red Hat, Inc., Jake Hunsaker <jhunsake@redhat.com>
+
+# This file is part of the rig project: https://github.com/TurboTurtle/rig
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information
+
+from rigging.commands import RigCmd
+from rigging.connection import RigDBusConnection
+
+
+class TriggerCmd(RigCmd):
+    """
+    Used to manually trigger a deployed rig, instead of waiting for any of the
+    defined monitors to trigger normally.
+
+    This will immediately cause all monitors to stop, and all defined actions
+    to be taken as if the rig was triggered by one of the monitors.
+
+    If multiple rigs are specified, they will be triggered one at a time, but
+    will not wait for the preceding rig to finish triggering its actions.
+    """
+
+    parser_description = 'Manually trigger a rig right now'
+
+    @classmethod
+    def add_parser_options(cls, parser):
+        parser.add_argument('rig_id', nargs='+',
+                            help='The ID or name of the rig(s) to trigger')
+
+    def execute(self):
+        for target in self.options['rig_id']:
+            try:
+                _rig = RigDBusConnection(target)
+                _rig.trigger()
+                self.ui_logger.info(f"Rig '{target}' triggered")
+            except Exception as err:
+                self.ui_logger.error(f"Failed triggering '{target}': {err}")

--- a/rigging/connection.py
+++ b/rigging/connection.py
@@ -117,6 +117,9 @@ class RigDBusConnection:
     def info(self):
         return self._communicate(RigDBusCommand('info'))
 
+    def trigger(self):
+        return self._communicate(RigDBusCommand('trigger'))
+
 
 class RigDBusListener(dbus.service.Object):
     """
@@ -267,3 +270,16 @@ class RigDBusListener(dbus.service.Object):
             msg = f"Could not determine info: {error}"
             self.logger.error(msg)
             err(Exception(msg))
+
+    @dbus.service.method('com.redhat.RigInterface', in_signature='',
+                         out_signature='a{ss}', async_callbacks=('ok', 'err'))
+    def trigger(self, ok, err):
+        """
+        Manually trigger a rig so that it executes its actions immediately
+        """
+        try:
+            _func = self._get_mapped_method('trigger', err)
+            ok(RigDBusMessage(_func(), True).serialize())
+        except Exception as error:
+            self.logger.error(f"Failed triggering: {error}")
+            err(Exception(error))


### PR DESCRIPTION
This commit re-adds the `trigger` command, e.g. `rig trigger $id`, to allow users to manually trigger a rig's configured actions without waiting for one of its monitors to meet the specified condition(s).