### PR TITLE
[listcmd] Add parser description

### DIFF
--- a/rigging/commands/list.py
+++ b/rigging/commands/list.py
@@ -22,6 +22,8 @@ class ListCmd(RigCmd):
     `rig info` command.
     """
 
+    parser_description = 'List all current rigs on this system'
+
     def execute(self):
         bus = dbus.SessionBus()
         rigs = {}


### PR DESCRIPTION
Adds a description for the argparse help output for the `list` command.