### PR TITLE
[docs] Add action and monitor manpages

### DIFF
--- a/man/en/rig-actions-gcore.7
+++ b/man/en/rig-actions-gcore.7
@@ -1,0 +1,86 @@
+.TH rig-actions-gcore 7 "May 2023"
+
+.SH NAME
+rig action gcore - Collect an application memory dump via gcore
+
+.SH DESCRIPTION
+The gcore action allows users to collect an application memory dump (or "core") from
+a running application as a result of a rig being triggered.
+
+gcore is provided by GDB, which should be ubiquitous across Linux distributions, so in
+most use cases no additional packages need to be installed on the system in order to leverage
+this action.
+
+.SH USAGE
+
+Users may enable this action by specifying it as an action key in their rigfile, and
+providing it at least one process name or PID to capture.
+
+.LP
+  actions:
+    gcore:
+      procs: 24601
+.LP
+
+In the above example, when the accompanying rig is triggered this action will collect
+a memory dump file from the process with PID 24601.
+
+.SH FIELDS
+
+The gcore action supports the following fields as part of its configuration in a rigfile:
+
+.TP
+.B procs
+Required. Specify either single process or a list of processes to capture memory dumps from.
+Processes may use either PIDs or process names, such that they appear in output such as 'ps'.
+
+Accepts: string, integer, or list of strings and/or integers
+.TP
+.B freeze
+If enabled, gcore will "freeze" the process prior to initiating the memory dump. This involves
+sending a SIGSTOP to the process beforehand, and a SIGCONT after the memory dump is complete.
+
+Accepts: bool
+
+Default: False
+.TP
+.B repeat
+This action is repeatable, so users may collect multiple iterations of a memory dump from the same
+set of processes during its execution.
+
+Accepts: integer
+
+Default: 0
+.PP
+
+.SH EXAMPLES
+
+A basic gcore action configured for a single process, 'javert':
+.LP
+  actions:
+    gcore:
+      procs: javert
+.LP
+
+
+Another configuration that collects a total of 3 core dumps each from multiple processes,
+and sends a SIGSTOP to each before collecting the memory dumps:
+.LP
+  actions:
+    gcore:
+      repeat: 2
+      procs:
+        - 24601
+        - javert
+      freeze: True
+.LP
+
+
+.SH SEE ALSO
+.BR rig-create (1)
+.BR gcore (1)
+
+.SH MAINTAINER
+.nf
+Jake Hunsaker <jhunsake@redhat.com>
+.fi

--- a/man/en/rig-actions-kdump.7
+++ b/man/en/rig-actions-kdump.7
@@ -1,0 +1,65 @@
+.TH rig-actions-kdump 7 "May 2023"
+
+.SH NAME
+rig action kdump - Initiate collection of a system vmcore via kdump
+
+.SH DESCRIPTION
+Kdump is a service that collects the memory state of the kernel at the time of a fatal system error
+and saves it to disk for later review - often referred to as a "vmcore". This actions facilitates
+forcing such a fatal error for the express purpose of generating a vmcore at the time a rig is triggered.
+
+Note that this action does \fBnot\fR perform any kind of validation on the local configuration of the kdump
+service. Users must ensure that kdump is functional prior to relying on this action. Further, users must be aware
+that initiating a kdump collection \fBwill restart the system on which rig is running.\fR Lastly, because kdump requires
+that the system be restarted as part of the collection process, the actual vmcore file will \fBnot\fR be included
+in the tar archive rig generates. It will instead be in the location configured by the kdump service.
+
+Specifically, this action leverages a system's /proc/sysrq-trigger feature in order to artificially
+induce a kernel panic.
+
+.SH USAGE
+This action requires an explicit setting of the 'enabled' setting to ensure that the use of this
+action is strictly intentional:
+
+.LP
+  actions:
+    kdump:
+      enabled: True
+.LP
+
+.SH FIELDS
+The kdump action supports the following fields as part of its configuration:
+
+.TP
+.B enabled
+Required. This field must be set to True in order for this action to be used.
+
+Accepts: bool
+
+Default: False
+.TP
+.B sysrq
+If set, write this value to /proc/sys/kernel/sysrq which may influence the behavior of the sysrq key.
+
+Accepts: integer
+
+Default: null
+
+.SH EXAMPLES
+
+Basic configuration which also enables the sysrq function if presently disabled:
+.LP
+  actions:
+    kdump:
+      enabled: True
+      sysrq: 1
+.LP
+
+.SH SEE ALSO
+.BR rig-create (1)
+.BR kdump.conf (5)
+
+.SH MAINTAINER
+.nf
+Jake Hunsaker <jhunsake@redhat.com>
+.fi

--- a/man/en/rig-actions-noop.7
+++ b/man/en/rig-actions-noop.7
@@ -1,0 +1,28 @@
+.TH rig-actions-noop 7 "May 2023"
+
+.SH NAME
+rig action noop - An action that does nothing, but is useful for testing
+
+.SH DESCRIPTION
+The noop action does nothing. It is mainly useful in testing the configuration of
+a rig's monitors without triggering any real actions before users are confident that
+a given configuration meets their needs.
+
+.SH USAGE
+
+The noop action must be explicitly enabled:
+
+.LP
+  actions:
+    noop:
+      enabled: True
+.LP
+
+.SH FIELDS
+
+The noop action does not support any additional fields.
+
+.SH MAINTAINER
+.nf
+Jake Hunsaker <jhunsake@redhat.com>
+.fi

--- a/man/en/rig-actions-sos.7
+++ b/man/en/rig-actions-sos.7
@@ -1,0 +1,268 @@
+.TH rig-actions-sos 7 "May 2023"
+
+.SH NAME
+rig action sos - Generate an sos report or collect archive
+
+.SH DESCRIPTION
+The sos action provides the ability to generate an \fB sos report\fR or \fB sos collect\fR
+archive as part of the response to a triggered rig. sos is a diagnostic collection utility that
+is often used by commercial support entities for Linux distributions, applications, and platforms.
+
+The most popular feature of sos is "report" which will gather troubleshooting data on a system
+based on that system's configuration. The data gathered includes system configuration details,
+log files, command output, and more.
+
+The "collect" functionality of sos is designed to provide a report archive from multiple nodes
+at the same time.
+
+This action can be used in place of piecemeal data collection due to the breadth and scope
+of data that sos gathers.
+
+
+.SH USAGE
+
+To use the sos action, simply specify it in the rigfile, along with \fBeither\fR the report or
+collect function, for example:
+
+.LP
+  actions:
+    sos:
+      report: enabled
+.LP
+
+In the above example, an sos report will be gathered according to utility and system defaults.
+
+In order to control how the sos report is executed, users may provide additional fields to "report"
+or "collect" rather than simply specifying "enabled". See FIELDS for more information.
+
+.SH FIELDS
+
+The sos action supports 3 primary fields in its configuration:
+
+.TP
+.B initial_archive
+If specified, this action will gather an archive before the rig begins monitoring
+for the configured event(s). This archive will be executed in the exact same way as the triggered collection will.
+
+Accepts: bool
+
+Default: False
+.TP
+.B report
+Have the local sos utility collect a "report" archive when the rig is triggered. If you wish for sos to execute using only
+defaults, set this field to "enabled". Otherwise, see below for additional configuration options that may be passed here.
+.TP
+.B collect
+Have the local sos utility generate a "collect" archive; that is an archive of "report" archives from different nodes.
+If you wish for sos to execute using only defaults, set this field to "enabled". Otherwise, see below for additional
+configuration options that may be passed here.
+.PP
+
+To control how sos gathers either a report or collect execution, define either "report" or "collect as a yaml dictionary,
+using any of the following fields for configuration.
+.PP
+
+.TP
+.B case_id
+The case or ticket reference number that this archive is being collected for, if any. This will be reflected in
+the archive name.
+
+Accepts: string or number
+
+Default: null
+.TP
+.B clean
+After the archive is collected, attempt to obfuscate sensitive items in the report. Note that this is the same as
+passing the \fB--clean\fR option to sos if you were to invoke it yourself.
+
+Accepts: bool
+
+Default: False
+.TP
+.B only_plugins
+Only run the plugins specified here, rather than relying on the sos utility to enable plugins based
+on system configuration (such as package installation).
+
+Accepts: list of plugin names
+
+Default: []
+.TP
+.B skip_plugins
+Do not run the plugins listed here if they would otherwise be enabled.
+
+Accepts: list of plugin names
+
+Default: []
+.TP
+.B enable_plugins
+Explicitly enable the plugins listed here, even if they would otherwise not be enabled.
+
+Accepts: list of plugin names
+
+Default: []
+.TP
+.B plugin_option
+Control plugin-specific options; analogous to passing sos the \fB-k\fR or \fB--plugin-option\fR option
+on the commandline.
+
+Plugin options take the form \fBplugin_name.option_name: value\fR.
+
+Accepts: A dictionary whose keys are plugin_name.option_name and whose values are the plugin option's value to set
+
+Default: {}
+.TP
+.B log_size
+Specify the maximum file size (in MB) that sos should gather for any particular collection.
+
+Accepts: integer
+
+Default: 25
+.TP
+.B skip_commands
+Users may specify certain commands to skip collection of, rather than disabling the whole
+plugin that executes those commands. Generally, these will need to be provided in the form of
+UNIX shell-style globs as the whole string is used for command matching.
+
+For example, use 'hostname*' to skip all commands that begin with the string 'hostname'.
+
+Accepts: list of strings
+
+Default: []
+.TP
+.B skip_files
+Skip collection files matching any pattern specified with this option. This option may
+be either the full file path, or a UNIX shell-style pattern (e.g. '/etc/*release').
+
+Accepts: list of strings
+
+Default: []
+.TP
+.B verify
+Instruct sos to leverage the host's package manager to verify all installed packages.
+Note that this may significantly increase the run time of the sos action (including if
+the \fBinitial_archive\fR option is set to True).
+
+Accepts: bool
+
+Default: False
+.PP
+
+In addition to the above, if this action is configured for \fBcollect\fR, the following
+additional fields may be used to control how the \fBsos collect\fR command is executed.
+
+\fBNOTE:\fR sos collect makes remote connections to nodes other than localhost in order to
+gather reports from those nodes. In most cases this is done via SSH multiplexing (but may be controlled
+by either the cluster_type or transport options). It is \fBassumed\fR that SSH keys are deployed for such
+connections to be made successfully.
+
+.TP
+.B primary
+Specify the primary node for collection. sos collect uses a primary node to enumerate of node
+address/hostnames which it will connect to in order to generate a report from. This is generally
+a cluster master, controller, manager, or similarly named entity.
+
+If no primary node is given, sos collect assumes that localhost can be used for such enumeration.
+
+Accepts: hostname or IP address (string)
+
+Default: None (localhost will be used)
+.TP
+.B cluster_type
+By default, sos collect attempts to identify any installed cluster software in order to be able
+to enumerate other nodes to gather reports from. Use this field to skip automatic detection and force
+the use of a given cluster profile. See \fBsos collect -l\fR for the cluster profiles your sos installation
+supported.
+
+Accepts: string
+
+Default: None
+.TP
+.B cluster_option
+Set cluster-specific options, similar to \fBplugin_option\fR above. Pass cluster options as a dictionary
+whose keys are the form of \fBcluster_name.option_name\fR and whose value is the value to set the option to.
+
+Accepts: dictionary
+
+Default: {}
+.TP
+.B nodes
+Provide a list of nodes to connect to in order to collect an sos report from them.
+Node addresses may either be hostnames (use FQDNs for best results) or IP addresses.
+
+Accepts: list of strings
+
+Default: []
+.TP
+.B no_local
+Do not capture an sos report from the localhost. This may be useful if the local system rig is running on
+is able to determine that a given cluster has an issue that warrants sos collection, but is not relevant to the
+actual troubleshooting that needs to happen for that cluster.
+
+Accepts: bool
+
+Default: False
+.TP
+.B ssh_user
+Specify the user to make remote connections as. Note that some non-SSH transports make use of this option to set the
+connecting user.
+
+Accepts: string
+
+Default: root
+.TP
+.B timeout
+Specify the amount of time in seconds to allow an \fBindividual\fR sos report collection to take before cancelling
+the collection of that node.
+
+Accepts: integer
+
+Default: 300
+.TP
+.B transport
+Specify the remote transport protocol to use to make connections to the nodes in order to general reports.
+See \fBsos-collect (1)\fR for a list of supported transports.
+
+Accepts: string
+
+Default: None (ssh will be used)
+.PP
+
+.SH EXAMPLES
+.PP
+Example configuration to gather a local report, disabling the 'cgroups' plugin, and configuring a kernel plugin option:
+.LP
+  actions:
+    sos:
+      report:
+        skip_plugins:
+          - cgroups
+        plugin_option:
+          kernel.trace: on
+.LP
+
+Another configuration that collects an initial baseline report prior to beginning monitoring, and does not specify any non-default
+behavior:
+.LP
+  actions:
+    sos:
+      initial_archive: True
+      report: enabled
+
+Action configuration to use the "collect" functionality, to collect from a cluster whose primary node is foo.bar.com:
+.LP
+  actions:
+    sos:
+      collect:
+        primary: foo.bar.com
+        no_local: True
+.LP
+
+.SH SEE ALSO
+.BR rig-create (1)
+.BR sos-report (1)
+.BR sos-collect (1)
+
+.SH MAINTAINER
+.nf
+Jake Hunsaker <jhunsake@redhat.com>
+.fi

--- a/man/en/rig-actions-tcpdump.7
+++ b/man/en/rig-actions-tcpdump.7
@@ -1,0 +1,98 @@
+.TH rig-actions-tcpdump 7 "May 2023"
+
+.SH NAME
+rig actions tcpdump - Collect a packet capture over the life of the rig
+
+.SH DESCRIPTION
+Users may configure this action in order to collect a packet capture over the course
+of the life of the rig. Unlike most actions, the tcpdump action begins its collections when
+the rig is first deployed, and terminates its collection once the rig is triggered.
+
+In other words, network traffic is recorded up until the problem a rig is configured to
+watch for occurs.
+
+Note that users may see a short delay in the setup of rigs using this action, as rig will
+attempt to validate that a packet capture is possible with the given configuration prior to
+monitoring for the problem condition.
+
+.SH USAGE
+The tcpdump action can be configured with as little as the name of the network interface users
+wish to capture network traffic with:
+
+.LP
+  actions:
+    tcpdump:
+      interface: eth0
+.LP
+
+.SH FIELDS
+
+The tcpdump action supports the following fields in order to control how the packet capture
+records network traffic:
+.TP
+.B interface
+Required. Provide the interface to capture network traffic with. This interface must really exist,
+and must be usable by tcpdump. A value of "any" may be used to listen across all interfaces, however
+that may render recorded traffic useless for analysis.
+
+Accepts: string
+.TP
+.B expression
+Provide a filtering expression for tcpdump to use, in order to restrict the amount of data recorded.
+If omitted all traffic across the interface is captured, which may result in either an extremely large
+pcap file, or may result in capture files being rotated frequently enough to overwrite the desired data.
+
+See \fBpcap-filter\fR(7) for expression syntax.
+
+Accepts: string
+.TP
+.B capture_count
+Save this many number of capture files. In conjunction with the \fBcapture_size\fR field this allows
+tcpdump to keep only the most recent (and therefore assumed to be most relevant) network traffic data.
+
+Accepts: integer
+
+Default: 1 (no rotated copies kept)
+.TP
+.B capture_size
+Limit each pcap file created by tcpdump to be this size, in MB, at most.
+
+Accepts: integer
+
+Default: 10
+.TP
+.B snapshot_length
+Capture this amount of \fBbytes\fR from each packet. Be careful in setting this value below
+tcpdump's default of 262144 bytes as this may render captured packets useless for analysis.
+
+Accepts: integer
+
+Default: 0 (use tcpdump default of 262144)
+
+.SH EXAMPLES
+
+Basic configuration that allows for 3 pcap files, capturing from eth0:
+.LP
+  actions:
+    tcpdump:
+      interface: eth0
+      capture_count: 3
+.LP
+
+A configuration that applies a packet filter expression:
+.LP
+  actions:
+    tcpdump:
+      interface: eth0
+      expression: "dst 192.168.0.1 and not udp"
+.LP
+
+.SH SEE ALSO
+.BR rig-create (1)
+.BR tcpdump (1)
+.BR pcap-filter (7)
+
+.SH MAINTAINER
+.nf
+Jake Hunsaker <jhunsake@redhat.com>
+.fi

--- a/man/en/rig-actions-watch.7
+++ b/man/en/rig-actions-watch.7
@@ -1,0 +1,113 @@
+.TH rig-actions-watch 7 "May 2023"
+
+.SH NAME
+rig action watch - Periodically collect file content and/or command output
+
+.SH DESCRIPTION
+The watch action allows users to periodically record particular data of interest
+at a set interval over the life of the rig. This action begins its collection when the
+rig is first deployed, and stops its collection once the rig has been triggered.
+
+For each file or command specified by this action's configuration, a recording file will
+be saved in the rig's archive. The contents of this file will be the content of the target file
+or the output of the target command, separated with a timestamp header. This allows users
+to track changes in system state over a time period leading up to the monitored condition.
+
+By using the \fBdelay\fR field in rigfiles, users may also continue to capture this information
+after a rig has been triggered up to the number of seconds specified by the delay value.
+
+Note that the periodicity of recordings is controlled by the rig's top-level \fBinterval\fR value,
+which defaults to every 1 second.
+
+.SH USAGE
+
+To use the watch action with a standardized set of files and commands to record, user may
+configure the following:
+
+.LP
+  actions:
+    watch:
+      use_standard_set: True
+.LP
+
+The collections enabled by use_standard_set are defined below.
+
+.SH FIELDS
+
+The watch action supports the following fields in its configuration:
+.TP
+.B files
+Specify the file or files to record. This field is a list of dictionaries that take the keys of
+'path' and optionally 'dest' to control what file is collected and what it is named inside the
+archive.
+
+  \fBpath\fR
+  The 'path' key specifies the path of the file to record. This must be a real filepath and not
+  a glob or similar.
+
+  \fBdest\fR
+  If provided, save the contents of the file specified by 'path' to a file named this in the archive.
+  If omitted, the name of the file specified via path is used.
+
+Accepts: list of yaml dictionaries with keys of 'path' and 'dest'
+.TP
+.B commands
+Specify the commands to routinely execute and save the output of. Commands will be saved to
+files named after the entire command syntax, with spaces converted to underscores. While in many cases it may not
+be required to do so, it is recommended to quote all commands that are passed any options.
+
+Note that embedded shell code will \fBnot\fR work here. If output needs to be piped or otherwise compiled between
+multiple commands, provide that functionality in a shell script and have the watch action call that script.
+
+Accepts: list of strings
+.TP
+.B use_standard_set
+Automatically load a standardized set of file and command collections that are traditionally
+useful to support organizations. Note that this is an all-or-nothing option, and specific
+collections within this set cannot be disabled. Any entries for \fBfiles\fR or \fBcommands\fR for
+this action's configuration will be in addition to this set, if enabled.
+
+  Files collected by use_standard_set:
+
+    /proc/interrupts
+    /proc/vmstat
+    /proc/net/softnet_stat
+    /proc/softirqs
+    /proc/net/sockstat
+    /proc/net/sockstat6
+    /proc/net/dev
+    /proc/net/sctp/assocs
+    /proc/net/sctp/snmp
+
+  Commands collected by use_standard_set:
+
+    netstat -s
+    nstat -az
+    ss -noemitaup
+    ps -alfe
+    top -c -b -n 1
+    numastat
+    ip neigh show
+    tc -s qdisc
+    tc -s class show dev $device (for any qdisc devices)
+
+.SH EXAMPLES
+
+A configuration in which the contents of 2 files and a command's output are collected:
+
+.LP
+  actions:
+    watch:
+      files:
+        - path: /etc/hostname
+        - path: /var/log/myservice_output.log
+          dest: service.log
+      commands:
+        - "uname -r"
+.LP
+
+.SH MAINTAINER
+.nf
+Jake Hunsaker <jhunsake@redhat.com>
+.fi
+

--- a/man/en/rig-monitors-cpu.7
+++ b/man/en/rig-monitors-cpu.7
@@ -1,0 +1,92 @@
+.TH rig-monitors-cpu 7 "May 2023"
+
+.SH NAME
+rig monitor cpu - Monitor CPU usage metrics
+
+.SH DESCRIPTION
+The cpu monitor allows users to trigger a rig based on the amount of cpu time that a system
+spends in a certain state or metric.
+
+Users may monitor for total cpu usage, or the amount of time spent in areas such as
+iowait, steal, and more, expressed as a percentage.
+
+.SH USAGE
+A cpu monitor may be defined with any or even all of the supported metrics. A basic example
+monitoring total cpu usage would be as follows:
+
+.LP
+  monitors:
+    cpu:
+      percent: 50
+.LP
+
+Which in this case would trigger the rig whenever total cpu usage goes over 50%.
+
+.SH FIELDS
+The cpu monitor supports the following fields as part of its configuration:
+.TP
+.B percent
+Monitor overall cpu usage as a percentage of total cpu available.
+
+Accepts: integer
+.TP
+.B iowait
+Threshold value for amount of cpu time where the cpu (or cpus) were idle during which
+the system had pending disk I/O, expressed as a percentage.
+
+Accepts: integer
+.TP
+.B steal
+Threshold value for amount of virtual cpu time spent waiting on the physical cpu, expressed
+as a percentage.
+
+Accepts: integer
+.TP
+.B system
+Threshold value for amount of time spent running kernel code, expressed as a percentage.
+
+Accepts: integer
+.TP
+.B nice
+Threshold value for amount of cpu time occupied by user level processes with positive nice
+values, expressed as a percentage.
+
+Accepts: integer
+.TP
+.B guest
+Threshold value for amount of cpu time spent running a virtual processor, expressed as a
+percentage.
+
+Accepts: integer
+.TP
+.B guest_nice
+Threshold value for amount of cpu time occupied by user level processes within a virtual processor
+with a positive nice value, expressed as a percentage.
+
+Accepts: integer
+.TP
+.B user
+Threshold value for amount of cpu time spent running user-mode code.
+
+Accepts: integer
+
+.SH EXAMPLES
+
+Any or all of the above fields may be used to configure this monitor. One configuration
+that watches overall usage as well as iowait time may look like this:
+
+.LP
+  monitors:
+    cpu:
+      percent: 60
+      iowait: 30
+.LP
+
+.SH SEE ALSO
+.BR rig-create (1)
+
+.SH MAINTAINER
+.nf
+Jake Hunsaker <jhunsake@redhat.com>
+.fi
+

--- a/man/en/rig-monitors-filesystem.7
+++ b/man/en/rig-monitors-filesystem.7
@@ -1,0 +1,87 @@
+.TH rig-monitors-filesystem 7 "May 2023"
+
+.SH NAME
+rig monitor filesystem - Monitor a filesystem, directory, or file for changes
+
+.SH DESCRIPTION
+The filesystem monitor allows users to configure a rig to trigger actions once a particular
+change has occurred to a filesystem, directory, or specific file.
+
+These changes are focused around disk space usage, meaning for example a file reaching a
+certain size, or a filesystem reaching a low amount of available space left.
+
+Note that this monitor does not watch the actual contents of the target - for that, users
+should use the \fBlogs\fR monitor.
+
+.SH USAGE
+
+The filesystem monitor needs at minimum a path, and at least one defined size criteria:
+
+.LP
+  monitors:
+    filesystem:
+      path: /var/log/rig/rig.log
+      size: 1G
+.LP
+
+This configuration would trigger the rig once rig.log reaches a size of 1 GiB.
+
+.SH FIELDS
+The filesystem monitor supports the following fields as part of its configuration:
+.TP
+.B path
+Required. The path to monitor for size changes. This can be a directory or a file,
+but the path must currently exist on the system.
+
+Accepts: string
+.TP
+.B size
+The threshold size of the target path to trigger on. For directories this means the total
+combined size of all contents within the directory, recursively.
+
+Values may be specified using the common K, M, G, T, and P suffixes.
+
+Accepts: string
+.TP
+.B used_perc
+Instead of monitoring the size of path directly, monitor the total amount of space used
+for the backing filesystem, expressed as a percentage.
+
+Accepts: integer
+.TP
+.B used_size
+The threshold size for total amount of space used for the backing filesystem, rather than
+the size of path directly.
+
+Values may be specified using the common K, M, G, T, and P suffixes.
+
+Accepts: string
+
+.SH EXAMPLES
+
+A basic configuration watching a directory growing over 2 GiB in size:
+
+.LP
+  monitors:
+    filesystem:
+      path: /var/log/myservice
+      size: 2G
+.LP
+
+In this example, rig will monitor the filesystem backing the path specified and trigger
+when it is 80% used or more:
+
+.LP
+  monitors:
+    filesystem:
+      path: /mnt/external_backup/
+      used_perc: 80
+.LP
+
+.SH SEE ALSO
+.BR rig-create (1)
+
+.SH MAINTAINER
+.nf
+Jake Hunsaker <jhunsake@redhat.com>
+.fi

--- a/man/en/rig-monitors-logs.7
+++ b/man/en/rig-monitors-logs.7
@@ -1,0 +1,97 @@
+.TH rig-monitors-logs 7 "May 2023"
+
+.SH NAME
+rig monitor logs - Monitor log files and journals for matching content
+
+.SH DESCRIPTION
+The logs monitor allows users to trigger data collection based on the appearance of specific
+message(s) in specific log files or journals, which is likely the easiest way to identify when
+a problem condition has been hit.
+
+Users may provide either exact messages to match, or provide message patterns to allow for flexibility
+in the way a log message might appear.
+
+.SH USAGE
+The logs monitor requires at a minimum the message field to define what log message to look for:
+
+.LP
+  monitors:
+    logs:
+      message: "this is my test message"
+.LP
+
+By default this monitor will watch well-known logs and journals, but this may be more specifically
+defined by users. See FIELDS for more information.
+
+.SH FIELDS
+The logs monitor supports the following fields as part of its configuration:
+.TP
+.B message
+Required. Provide either the exact message string or a message pattern to trigger on.
+
+Note: for message patterns, rig supports the use of \fBpython\fR regular expressions. UNIX shell-style
+globs will not function as anticipated if they are used. See \fBpython -c 'import re; help(re)'\fR for
+more information of python regex syntax.
+
+The value passed to this field should be quoted for best results.
+
+Accepts: string
+.TP
+.B count
+Specify the number of times the message or message pattern must be matched. This counter is applied
+across all monitored files and journals simultaneously.
+
+Accepts: integer
+
+Default: 1
+.TP
+.B files
+Provide the file(s) to monitor for the specified message. These files must exist at the time of
+rig creation. Non-existing files will be ignored, rather than cause a configuration error. Set to
+null to not watch any files.
+
+Accepts: string or list of strings
+
+Default: /var/log/messages
+.TP
+.B journals
+Provide the journal unit(s) to monitor for the specified message. If it is not desired to
+watch any journals, set this to null. The default value of 'system' implies the entire journal
+is watched without filtering by specific units/services.
+
+Accepts: string or list of strings
+
+Default: system
+
+.SH EXAMPLES
+
+Basic configuration that watches the system journal and /var/log/foobar.log:
+
+.LP
+  monitors:
+    logs:
+      message: "this is my test message"
+      files: /var/log/foobar.log
+.LP
+
+This configuration uses a message pattern, requires being seen 3 times, and watches
+only two specific journals:
+
+.LP
+  monitors:
+    logs:
+      message: "Process with name myservice-(.*)? has crashed"
+      count: 3
+      files: null
+      journals:
+        - myservice
+        - another-service
+.LP
+
+.SH SEE ALSO
+.BR rig-create (1)
+
+.SH MAINTAINER
+.nf
+Jake Hunsaker <jhunsake@redhat.com>
+.fi

--- a/man/en/rig-monitors-memory.7
+++ b/man/en/rig-monitors-memory.7
@@ -1,0 +1,68 @@
+.TH rig-monitors-memory 7 "May 2023"
+
+.SH NAME
+rig monitor memory - Watch system memory utilization metrics
+
+.SH DESCRIPTION
+The memory monitor allows users to trigger a rig based on the current usage of system memory,
+ and/or by select metrics about memory allocation.
+
+.SH USAGE
+The memory monitor is most commonly configured to watch total consumption of system memory:
+
+.LP
+  monitors:
+    memory:
+      percent: 80
+.LP
+
+.SH FIELDS
+The memory monitor supports the following fields as part of its configuration:
+.TP
+.B percent
+The threshold value of total system memory consumption to trigger on, expressed as
+a percentage.
+
+Note that this is calculated as follows:
+    (total - available) / total * 100
+
+In this calculation, available memory is defined as memory that can be given instantly
+to processes with the system going to swap.
+
+Accepts: integer or float
+.TP
+.B used
+The threshold value for the amount of actively used memory to trigger on.
+
+This is different from the 'percent' field. 'used' memory is calculated as:
+    total - free
+
+Values may use the common K, M, G, or T suffixes.
+
+Accepts: string
+.TP
+.B slab
+The amount of memory currently held in slabs.
+
+Values may use the common K, M, G, or T suffixes.
+
+Accepts: string
+
+.SH EXAMPLES
+In addition to the basic percent example shown in USAGE above, the fields may be
+used simultaneously with each other:
+
+.LP
+  monitors:
+    memory:
+      percent: 80
+      slab: 1G
+.LP
+
+.SH SEE ALSO
+.BR rig-create (1)
+
+.SH MAINTAINER
+.nf
+Jake Hunsaker <jhunsake@redhat.com>
+.fi

--- a/man/en/rig-monitors-process.7
+++ b/man/en/rig-monitors-process.7
@@ -1,0 +1,118 @@
+.TH rig-monitors-process 7 "May 2023"
+
+.SH NAME
+rig monitor process - Watch a process for a change in state or resource consumption
+
+.SH DESCRIPTION
+The process monitor allows users to watch a process, or set of processes, for changes in
+their state and/or for reaching certain resource consumption thresholds.
+
+Processes may be specified either by PID or by name.
+
+.SH USAGE
+The process monitor requires at least one process name or PID, and at least one metric
+to watch:
+
+.LP
+  monitors:
+    process:
+      procs: 24601
+      cpu_percent: 50
+.LP
+
+.SH FIELDS
+The process monitor supports the following fields as part of its configuration:
+.TP
+.B procs
+Required. Specify the name or PID of the process (or processes) to monitor. If given
+a name that matches multiple processes, all matched processes will be watched independently.
+
+Accepts: string, integer, or list of strings and integers
+.TP
+.B cpu_percent
+The threshold amount of total cpu time consumed by the process to trigger on, expressed
+as a percentage.
+
+Accepts: integer
+.TP
+.B memory_percent
+The threshold amount of total memory consumed by the process to trigger on.
+
+Values may use the common K, M, G, or T suffixes.
+
+Accepts: string
+.TP
+.B rss
+The threshold amount of resident set size of the process to trigger on.
+
+Values may use the common K, M, G, or T suffixes.
+
+Accepts: string
+.TP
+.B vms
+The threshold virtual memory size of the process to trigger on.
+
+Values may use the common K, M, G, or T suffixes.
+
+Accepts: string
+.TP
+.B state
+The state of the process to trigger - either when the process enters the given state,
+or leaves a desired state.
+
+The states that can be monitored are defined below - users may specify the name or short-hand
+in the value of this field.
+
+        NAME                SHORT HAND          DESCRIPTION
+        running             R, run              The process is actively running
+        sleeping            S, sleep            The process is currently sleeping
+        stopped             T, stop             The process has been stopped (SIGSTOP)
+        uninterruptible     D, UN, disk_sleep   Process is in uninterruptible sleep
+        zombie              Z                   Process is a zombie
+
+
+The default behavior of process monitors using the state field is to trigger when the
+process \fBenters\fR the specified state. For example, setting this to 'D' will cause
+the monitor to trigger the rig only when the process enters an uninterruptible sleep.
+
+This can be inverted however, by prefixing a '!' before the name or short hand for this value.
+For example using '!sleeping' will trigger the rig whenever the process is \fBnot\fR sleeping.
+
+Note: if the value of this is set to '!running', the rig will \fBnot\fR be triggered when the
+process is sleeping, as it is common for "processes that are running" to frequently sleep. The
+rig \fBwill\fR trigger however if the process exits.
+
+Accepts: string
+
+.SH EXAMPLES
+A basic configuration that watches a single process for cpu or memory consumption:
+
+.LP
+  monitors:
+    process:
+      procs: 24601
+      cpu_percent: 75
+      memory_percent: 50
+      rss: 4G
+.LP
+
+The following configuration will watch multiple processes by both PID and process name
+to stop running:
+
+.LP
+  monitors:
+    process:
+      procs:
+        - 24601
+        - javert
+      state: "!running"
+.LP
+
+.SH SEE ALSO
+.BR rig-create (1)
+.BR ps(1)
+
+.SH MAINTAINER
+.nf
+Jake Hunsaker <jhunsake@redhat.com>
+.fi

--- a/man/en/rig-monitors-system.7
+++ b/man/en/rig-monitors-system.7
@@ -1,0 +1,59 @@
+.TH rig-monitors-system 7 "May 2023"
+
+.SH NAME
+rig monitor system - Watch the overall system load or temperature sensor
+
+.SH DESCRIPTION
+The system monitor may be used to watch overall system load, as reported by its loadavg, and/or
+the temperature of the cpu as reported by the temperature sensor.
+
+.SH USAGE
+A simple loadavg system monitor may be configured as easily as:
+
+.LP
+  monitors:
+    system:
+      loadavg: 4
+.LP
+
+.SH FIELDS
+The system monitors supports the following fields as part of its configuration:
+.TP
+.B loadavg
+The threshold value of the system's loadavg to trigger on. Note that loadavg is a rough
+value to indicate relatively how busy a system currently is.
+
+Accepts: integer or float
+.TP
+.B loadavg_interval
+Which loadavg interval should the monitor be considering. loadavg is reported in
+1, 5, and 15 minute intervals.
+
+Accepts: 1, 5, or 15
+
+Default: 1
+.TP
+.B temperature
+Threshold value of the cpu temperature in Celsius to trigger on, as reported by
+the cpu's temperature sensor.
+
+Note: in the case of multiple physical cpu packages, only the physical processor in
+slot 0 is considered.
+
+Accepts: integer
+
+.SH EXAMPLES
+A configuration watching a supposedly heavily utilized system for both load and
+temperature:
+
+.LP
+  monitors:
+    system:
+      loadavg: 41.99
+      temperature: 75
+.LP
+
+.SH MAINTAINER
+.nf
+Jake Hunsaker <jhunsake@redhat.com>
+.fi

--- a/man/en/rig.1
+++ b/man/en/rig.1
@@ -33,7 +33,7 @@ Rigs are configured to check for specific conditions via the use of "monitors". 
 monitors are specific to a type of condition that users may be interested in leveraging to
 facilitate data collection via rig actions.
 
-See \fBrig-monitors\fR for detailed information on the available monitors.
+See \fBrig list-monitors\fR for detailed information on the available monitors.
 
 .SH ACTIONS
 
@@ -45,7 +45,7 @@ for the specific rig which generated was triggered.
 Actions generally center around data collection at the time a monitor's condition is met, however
 some such as the 'tcpdump' action may collect data over the life of the rig.
 
-See \fBrig-actions\fR for more detailed information on the available actions.
+See \fBrig list-actions\fR for more detailed information on the available actions.
 
 .SH MAINTAINER
 .nf


### PR DESCRIPTION
This patchset adds the updated manpages for the currently supported actions and monitors.

These are accessible via  e.g. `rig list-actions --show $action`  for action manpages once rig has been installed locally.