### PR TITLE
[build] Update build scripts for 2.0 alpha

### DIFF
--- a/man/en/rig-monitors-timer.7
+++ b/man/en/rig-monitors-timer.7
@@ -1,0 +1,62 @@
+.TH rig-monitors-timer 7 "May 2023"
+
+.SH NAME
+rig monitor timer - Ensure a rig is triggered after a certain amount of time
+
+.SH DESCRIPTION
+The timer monitor may be used to force a rig to trigger, or alternatively to destroy itself without
+triggering, after a given amount of time. This can be useful to make sure that rigs do not live past
+their intended use case.
+
+.SH USAGE
+The timer monitor may be configured with as little as a single option:
+
+.LP
+  monitors:
+    timer:
+      timeout: 1h
+.LP
+
+.SH FIELDS
+The timer monitor supports the following fields as part of its configuration:
+.TP
+.B timeout
+Required. Specify the amount of time to wait before this rig should be triggered.
+
+The following suffixes are used to denote how long a timeout should be:
+
+    s   seconds
+    m   minutes
+    h   hours
+    d   days
+    w   weeks
+
+These may be chained together in a single string, for example '1d4h30m' may be used
+to denote 1 day, 4 hours, and 30 minutes for a timeout.
+
+Accepts: string
+.TP
+.B trigger_on_expiry
+The default behavior of this monitor is to trigger the rig once the timeout has passed,
+which implies the execution of all configured actions. This may be disabled, so that a rig simply
+terminates itself without executing any of its actions, by setting this to False.
+
+Accepts: bool
+
+Default: True
+
+.SH EXAMPLES
+This configuration will wait 7 days for the rig to trigger, after which time this monitor
+will cause the rig to terminate without executing its actions:
+
+.LP
+  monitors:
+    timer:
+      timeout: 1w
+      trigger_on_expiry: False
+.LP
+
+.SH MAINTAINER
+.nf
+Jake Hunsaker <jhunsake@redhat.com>
+.fi

--- a/rig.spec
+++ b/rig.spec
@@ -1,6 +1,6 @@
 Name:       rig
 Summary:    Monitor a system for events and trigger specific actions
-Version:    1.1
+Version:    2.0a
 Release:    1%{?dist}
 Url:        https://github.com/TurboTurtle/rig
 Source0:    %{url}/archive/%{name}-%{version}.tar.gz
@@ -28,13 +28,13 @@ troubleshooting and data collection for randomly occurring events.
 %py3_build
 
 %install
-mkdir -p ${RPM_BUILD_ROOT}%{_mandir}/man1
-install -p -m644 man/en/rig.1 ${RPM_BUILD_ROOT}%{_mandir}/man1/
 %py3_install
 
 %files
 %{_bindir}/rig
 %{_mandir}/man1/*
+%{_mandir}/man7/*
+
 
 %{python3_sitelib}/rig-*.egg-info/
 %{python3_sitelib}/rigging/

--- a/rigging/__init__.py
+++ b/rigging/__init__.py
@@ -22,6 +22,8 @@ from rigging.exceptions import CannotConfigureRigError, DestroyRig
 from rigging.utilities import load_rig_monitors, load_rig_actions
 from threading import Event
 
+__version__ = '2.0'
+
 
 class BaseRig():
     """

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,14 @@
+import os
+
 from setuptools import setup, find_packages
 from rigging import __version__ as VERSION
+
+def get_man_pages(section):
+    """Helper to always include all man pages in dist tarball"""
+    _dir = 'man/en/'
+    return [
+        os.path.join(_dir, m) for m in os.listdir(_dir) if m.endswith(section)
+    ]
 
 setup(
     name='rig',
@@ -26,5 +35,6 @@ setup(
     scripts=['rig'],
     data_files=[
         ('share/licenses/rig', ['LICENSE']),
-        ('share/man/man1/', ['man/en/rig.1'])
+        ('share/man/man1/', get_man_pages('1')),
+        ('share/man/man7/', get_man_pages('7'))
     ])


### PR DESCRIPTION
Update the build scripts to allow local building of the new design. Note this is *not* meant to indicate that the new design is ready to be packaged on downstream, so it is marked as an alpha version.

Also including in a separate commit the `timer` man page which was somehow skipped in the previous PR for docs.